### PR TITLE
handle streaming response, render correctly on UI

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -27,6 +27,7 @@ async def mock_async_generator():
     for idx, c in enumerate(streamable_str):
         if idx == end - 1:
             yield ServerSentEvent(data=c, event="end")
+            break
         yield ServerSentEvent(data=c, event="message")
         await asyncio.sleep(0.05)
     streamable_str = ""
@@ -43,5 +44,5 @@ def get_stream():
 @app.post("/stream")
 def post_user_message(payload: UserMessage):
     global streamable_str
-    streamable_str = payload.message
+    streamable_str = payload.message + " "
     return Response("success")


### PR DESCRIPTION
- uses Azure's fetchEventSource instead of the EventSource API: the standard
EventSource API just keeps sending requests for some reason, closing the
connection on disconnection might solve this but continue using fetchEventSource
given its additional features.
- update the aiResponse and messageHistory state via callback, having
the state update inside event listeners only take the state value of
initial render. Through callback, we can ensure that latest state updated